### PR TITLE
Fix log and data paths for MCP server compatibility

### DIFF
--- a/stockscreen.py
+++ b/stockscreen.py
@@ -19,14 +19,15 @@ from pathlib import Path
 
 # Default to a data directory in current working directory if not specified
 DEFAULT_DATA_PATH = os.environ.get('STOCKSCREEN_DATA_PATH', 
-    str(Path.cwd() / 'data'))
+    os.path.join(os.path.dirname(__file__), "data"))
+DEFAULT_LOG_PATH = os.path.join(os.path.dirname(__file__), "stockscreen_v1.log")
 
 # Configure logging
 logging.basicConfig(
     level=logging.INFO,
     format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
     handlers=[
-        logging.FileHandler("stockscreen_v1.log"),
+        logging.FileHandler(DEFAULT_LOG_PATH),
         logging.StreamHandler()
     ]
 )


### PR DESCRIPTION
## Summary
- Fixed DEFAULT_DATA_PATH to use script directory instead of current working directory
- Added DEFAULT_LOG_PATH variable for consistent logging location
- Ensures MCP server works correctly regardless of execution context

## Test plan
- [x] Test MCP server connection from different working directories
- [x] Verify log files are created in the correct location
- [x] Confirm data directory path resolution works as expected

🤖 Generated with [Claude Code](https://claude.ai/code)